### PR TITLE
Removal of 220T only mentions

### DIFF
--- a/SDM.h
+++ b/SDM.h
@@ -4,8 +4,8 @@
 *  crc calculation by Jaime García (https://github.com/peninquen/Modbus-Energy-Monitor-Arduino/)
 */
 
-#ifndef SDM220_T_h
-#define SDM220_T_h
+#ifndef SDM_h
+#define SDM_h
 //------------------------------------------------------------------------------
 #include <Arduino.h>
 #include <SoftwareSerial.h>
@@ -90,7 +90,7 @@
 
 //------------------------------------------------------------------------------
 template <long _speed = SDM_BAUD, int _rx_pin = SDMSER_RX, int _tx_pin = SDMSER_TX>
-struct SDM220 {
+struct SDM {
 
   SoftwareSerial sdmSer = SoftwareSerial(_rx_pin, _tx_pin, false, 32);
 

--- a/examples/sdm220_simple/sdm220_simple.ino
+++ b/examples/sdm220_simple/sdm220_simple.ino
@@ -1,12 +1,14 @@
-#include <SDM220_t.h>                                                           //import SDM220 template library
+#include <SDM.h>                                                           //import SDM220 template library
 
 #define ASCII_ESC 27
 
 char bufout[10];
 
-//SDM220<4800, 12, 13> sdm;                                                     //baud, rx pin, tx pin
-//or without parameters (default from SDM220_t.h will be used): 
-SDM220<> sdm;
+//SDM<2400, 12, 13> sdm;                                                     //SDM120T	baud, rx pin, tx pin
+//SDM<4800, 12, 13> sdm;                                                     //SDM220T	baud, rx pin, tx pin
+//SDM<9600, 12, 13> sdm;                                                     //SDM630	baud, rx pin, tx pin
+//or without parameters (default from SDM.h will be used): 
+SDM<> sdm;
 
 void setup() {
   Serial.begin(115200);                                                         //initialize serial


### PR DESCRIPTION
Since you opted to add the 630 and 120 registers i thought it was a good id to remove these and start with a default SDM call.